### PR TITLE
Update Spawn Handler to use CheckReplacement

### DIFF
--- a/zscript/10mmPistolZombie/mob_10mmpistolzombie.zs
+++ b/zscript/10mmPistolZombie/mob_10mmpistolzombie.zs
@@ -151,18 +151,18 @@ void A_Eject10mmPistolCasing(){
 		else chamber=0;
 	}
 	override void deathdrop(){
-		if(bhasdropped && tenpis_handgun_spawn_bias == -1)
+		if(bhasdropped && tenpis_pistol_spawn_bias == -1)
 		{
 			DropNewItem("HD9mMag15",96);
 		}
-		if (bhasdropped && tenpis_handgun_spawn_bias > -1)
+		if (bhasdropped && tenpis_pistol_spawn_bias > -1)
 		{
 			DropNewItem("HD10mMag8", 96);
 		}
  		else
 		{
 			bhasdropped=true;
-    		if (tenpis_handgun_spawn_bias == -1)
+    		if (tenpis_pistol_spawn_bias == -1)
 			{
 				let ppp=DropNewWeapon("HDPistol");
 				ppp.weaponstatus[PISS_MAG]=thismag;
@@ -190,7 +190,7 @@ void A_Eject10mmPistolCasing(){
 	}
 
 	void A_PistolGuyUnload(int which=0){
-		if(thismag>=0 && tenpis_handgun_spawn_bias == -1)
+		if(thismag>=0 && tenpis_pistol_spawn_bias == -1)
 		{
 			actor aaa;int bbb;
 			[bbb,aaa]=A_SpawnItemEx("HD9mMag15",
@@ -202,7 +202,7 @@ void A_Eject10mmPistolCasing(){
 			hdmagammo(aaa).mags.push(thismag);
 			A_StartSound("weapons/pismagclick",8);
 		}
-		if(thismag>=0&& tenpis_handgun_spawn_bias < -1)
+		if(thismag>=0&& tenpis_pistol_spawn_bias < -1)
 		{
 			actor aaa;int bbb;
 			[bbb,aaa]=A_SpawnItemEx("HD10mMag8",

--- a/zscript/10mmRifleman/mob_10mmRifleman.zs
+++ b/zscript/10mmRifleman/mob_10mmRifleman.zs
@@ -149,18 +149,18 @@ void A_Eject10mmPistolCasing(){
 		else chamber=0;
 	}
 	override void deathdrop(){
-		if(bhasdropped && sigcow_cbox_spawn_bias == -1)
+		if(bhasdropped && sigcow_clipbox_spawn_bias == -1)
 		{
 			DropNewItem("HD9mMag30",96);
 		}
-		if (bhasdropped && sigcow_cbox_spawn_bias > -1)
+		if (bhasdropped && sigcow_clipbox_spawn_bias > -1)
 		{
 			DropNewItem("HD10mMag25", 96);
 		}
  		else
 		{
 			bhasdropped=true;
-    		if (sigcow_cbox_spawn_bias == -1)
+    		if (sigcow_clipbox_spawn_bias == -1)
 			{
 				let ppp=DropNewWeapon("HDSMG");
 				ppp.weaponstatus[PISS_MAG]=thismag;
@@ -188,7 +188,7 @@ void A_Eject10mmPistolCasing(){
 	}
 
 	void A_PistolGuyUnload(int which=0){
-		if(thismag>=0 && sigcow_cbox_spawn_bias == -1)
+		if(thismag>=0 && sigcow_clipbox_spawn_bias == -1)
 		{
 			actor aaa;int bbb;
 			[bbb,aaa]=A_SpawnItemEx("HD9mMag30",
@@ -200,7 +200,7 @@ void A_Eject10mmPistolCasing(){
 			hdmagammo(aaa).mags.push(thismag);
 			A_StartSound("weapons/pismagclick",8);
 		}
-		if(thismag>=0&& sigcow_cbox_spawn_bias < -1)
+		if(thismag>=0&& sigcow_clipbox_spawn_bias < -1)
 		{
 			actor aaa;int bbb;
 			[bbb,aaa]=A_SpawnItemEx("HD10mMag25",

--- a/zscript/CombatShotgunGuy/mob_CombatShotgunZombie.zs
+++ b/zscript/CombatShotgunGuy/mob_CombatShotgunZombie.zs
@@ -58,7 +58,7 @@ class CombatJackboot:HDHumanoid{
 			bhasdropped=true;
 			hdweapon wp=null;
 
-			if(wep==0 && cshotgun_shotgun_spawn_bias == -1)
+			if(wep==0 && cshotgun_hunter_spawn_bias == -1)
 			{
 				wp=DropNewWeapon("Hunter");
 				if(wp){
@@ -76,7 +76,7 @@ class CombatJackboot:HDHumanoid{
 					gunloaded=8;
 				}
 			}
-			if(wep==0 && cshotgun_shotgun_spawn_bias > -1)
+			if(wep==0 && cshotgun_hunter_spawn_bias > -1)
 			{
 				wp=DropNewWeapon("HDCombatShotgun");
 				if(wp){

--- a/zscript/DoomedShotgunGuy/mob_DoomedShotgunZombie.zs
+++ b/zscript/DoomedShotgunGuy/mob_DoomedShotgunZombie.zs
@@ -111,7 +111,7 @@ class DoomedZombieShotgunner:HDHumanoid{
 					gunloaded=50;
 				}
 			}
-			if(wep==0 && dHunt_shotgun_spawn_bias > -1){
+			if(wep==0 && dHunt_hunter_spawn_bias > -1){
 				wp=DropNewWeapon("DoomHunter");
 				if(wp){
 					wp.weaponstatus[HUNTS_FIREMODE]=semi?1:0;
@@ -128,7 +128,7 @@ class DoomedZombieShotgunner:HDHumanoid{
 					gunloaded=8;
 				}
 			}
-			if(wep==0 && dHunt_shotgun_spawn_bias == -1){
+			if(wep==0 && dHunt_hunter_spawn_bias == -1){
 				wp=DropNewWeapon("Hunter");
 				if(wp){
 					wp.weaponstatus[HUNTS_FIREMODE]=semi?1:0;

--- a/zscript/RadTechZombie_Spawners.zs
+++ b/zscript/RadTechZombie_Spawners.zs
@@ -253,6 +253,9 @@ class RadtechZombiesHandler : EventHandler
 
     override void checkReplacement(ReplaceEvent e)
 	{
+		// Populates the main arrays if they haven't been already. 
+		if (!cvarsAvailable) init();
+
         // If there's nothing to replace or if the replacement is final, quit.
         if (!e.replacee || e.isFinal) return;
 
@@ -269,6 +272,9 @@ class RadtechZombiesHandler : EventHandler
 	
 	override void worldThingSpawned(WorldEvent e)
 	 {
+		// Populates the main arrays if they haven't been already. 
+		if (!cvarsAvailable) init();
+
 		// If thing spawned doesn't exist, quit.
 		if (!e.thing) return;
 

--- a/zscript/RadTechZombie_Spawners.zs
+++ b/zscript/RadTechZombie_Spawners.zs
@@ -333,9 +333,9 @@ class RadtechZombiesHandler : EventHandler
 				{
                     if (spawnReplace.name ~== candidateName)
 					{
-                        if (hd_debug) console.printf("Attempting to spawn "..itemSpawn.spawnName.." with "..candidateName.."...");
+                        if (hd_debug) console.printf("Attempting to spawn "..enemySpawn.spawnName.." with "..candidateName.."...");
 
-                        if (tryCreateItem(thing, enemySpawn.spawnName, spawnReplace.chance)) return;
+                        if (tryCreateEnemy(thing, enemySpawn.spawnName, spawnReplace.chance)) return;
                     }
                 }
             }

--- a/zscript/RadTechZombie_Spawners.zs
+++ b/zscript/RadTechZombie_Spawners.zs
@@ -1,260 +1,251 @@
-// Struct for Enemyspawn information. 
-class RTZSpawnEnemy play
-{
-	// ID by string for spawner
-	string spawnName;
+// Struct for Enemyspawn information.
+class RTZSpawnEnemy play {
 
-	// ID by string for spawnees
-	Array<RTZSpawnEnemyEntry> spawnReplaces;
-	
-	// Whether or not to persistently spawn.
-	bool isPersistent;
-	
-	// Whether or not to replace the original enemy
-	bool replaceEnemy;
+    // ID by string for spawner
+    string spawnName;
 
-	string toString()
-	{
-		let replacements = "[";
+    // ID by string for spawnees
+    Array<RTZSpawnEnemyEntry> spawnReplaces;
 
-		foreach (spawnReplace : spawnReplaces) replacements = replacements..", "..spawnReplace.toString();
+    // Whether or not to persistently spawn.
+    bool isPersistent;
 
-		replacements = replacements.."]";
+    // Whether or not to replace the original enemy
+    bool replaceEnemy;
 
-		return String.format("{ spawnName=%s, spawnReplaces=%s, isPersistent=%b, replaceEnemy=%b }", spawnName, replacements, isPersistent, replaceEnemy);
-	}
+    string toString() {
+
+        let replacements = "[";
+
+        foreach (spawnReplace : spawnReplaces) replacements = replacements..", "..spawnReplace.toString();
+
+        replacements = replacements.."]";
+
+        return String.format("{ spawnName=%s, spawnReplaces=%s, isPersistent=%b, replaceEnemy=%b }", spawnName, replacements, isPersistent, replaceEnemy);
+    }
 }
 
-class RTZSpawnEnemyEntry play
-{
-	string name;
-	int    chance;
+class RTZSpawnEnemyEntry play {
 
-	string toString()
-	{
-		return String.format("{ name=%s, chance=%s }", name, chance >= 0 ? "1/"..(chance + 1) : "never");
-	}
+    string name;
+    int    chance;
+
+    string toString() {
+        return String.format("{ name=%s, chance=%s }", name, chance >= 0 ? "1/"..(chance + 1) : "never");
+    }
 }
 
-// One handler to rule them all. 
-class RadtechZombiesHandler : EventHandler
-{
-	// List of persistent classes to completely ignore. 
-	// This -should- mean this mod has no performance impact. 
-	static const string blacklist[] =
-	{
-		'HDSmoke',
-		'BloodTrail',
-		'CheckPuff',
-		'WallChunk',
-		'HDBulletPuff',
-		'HDFireballTail',
-		'ReverseImpBallTail',
-		'HDSmokeChunk',
-		'ShieldSpark',
-		'HDFlameRed',
-		'HDMasterBlood',
-		'PlantBit',
-		'HDBulletActor',
-		'HDLadderSection'
-	};
-	
-	// List of Enemy-spawn associations.
-	// used for Enemy-replacement on mapload. 
-	array<RTZSpawnEnemy> EnemySpawnList;
-	
-	bool cvarsAvailable;
-	
-	// appends an entry to Enemyspawnlist;
-	void addEnemy(string name, Array<RTZSpawnEnemyEntry> replacees, bool persists, bool rep=true)
-	{
-		if (hd_debug)
-		{
-			let msg = "Adding "..(persists ? "Persistent" : "Non-Persistent").." Replacement Entry for "..name..": [";
+// One handler to rule them all.
+class RadtechZombiesHandler : EventHandler {
+    // List of persistent classes to completely ignore.
+    // This -should- mean this mod has no performance impact.
+    static const string blacklist[] = {
+        'HDSmoke',
+        'BloodTrail',
+        'CheckPuff',
+        'WallChunk',
+        'HDBulletPuff',
+        'HDFireballTail',
+        'ReverseImpBallTail',
+        'HDSmokeChunk',
+        'ShieldSpark',
+        'HDFlameRed',
+        'HDMasterBlood',
+        'PlantBit',
+        'HDBulletActor',
+        'HDLadderSection'
+    };
 
-			foreach (replacee : replacees) msg = msg..", "..replacee.toString();
+    // List of Enemy-spawn associations.
+    // used for Enemy-replacement on mapload.
+    array<RTZSpawnEnemy> EnemySpawnList;
 
-			console.printf(msg.."]");
-		}
+    bool cvarsAvailable;
 
-		// Creates a new struct;
-		RTZSpawnEnemy spawnee = RTZSpawnEnemy(new('RTZSpawnEnemy'));
-		
-		// Populates the struct with relevant information,
-		spawnee.spawnName = name;
-		spawnee.isPersistent = persists;
-		spawnee.replaceEnemy = rep;
-		spawnee.spawnReplaces.copy(replacees);
-		
-		// Pushes the finished struct to the array. 
-		enemySpawnList.push(spawnee);
-	}
+    // appends an entry to Enemyspawnlist;
+    void addEnemy(string name, Array<RTZSpawnEnemyEntry> replacees, bool persists, bool rep=true) {
 
-	RTZSpawnEnemyEntry addEnemyEntry(string name, int chance)
-	{
-		// Creates a new struct;
-		RTZSpawnEnemyEntry spawnee = RTZSpawnEnemyEntry(new('RTZSpawnEnemyEntry'));
-		spawnee.name = name;
-		spawnee.chance = chance;
-		return spawnee;
-	}
-	
-	// Populates the replacement and association arrays. 
-	void init()
-	{
-		cvarsAvailable = true;
-		
-    // --------------------
-		// Enemy spawn lists.
-    // --------------------
+        if (hd_debug) {
 
-    // Zombie Dog
-		Array<RTZSpawnEnemyEntry> spawns_zombiedog;  
-		spawns_zombiedog.push(addEnemyentry('Babuin', zombiedog_spawn_bias));
-		addEnemy('ZombieDog', spawns_zombiedog, zombiedog_persistent_spawning);
+            let msg = "Adding "..(persists ? "Persistent" : "Non-Persistent").." Replacement Entry for "..name..": [";
 
-    // Cloaked Zombie Dog 
-		Array<RTZSpawnEnemyEntry> spawns_cloaked_zombiedog;  
-		spawns_cloaked_zombiedog.push(addEnemyentry('SpecBabuin', cloaked_zombiedog_spawn_bias));
-		spawns_cloaked_zombiedog.push(addEnemyentry('NinjaPirate', cloaked_zombiedog_spawn_bias));
-		addEnemy('SpecZombieDog', spawns_cloaked_zombiedog, cloaked_zombiedog_persistent_spawning);
+            foreach (replacee : replacees) msg = msg..", "..replacee.toString();
+
+            console.printf(msg.."]");
+        }
+
+        // Creates a new struct;
+        RTZSpawnEnemy spawnee = RTZSpawnEnemy(new('RTZSpawnEnemy'));
+
+        // Populates the struct with relevant information,
+        spawnee.spawnName = name;
+        spawnee.isPersistent = persists;
+        spawnee.replaceEnemy = rep;
+        spawnee.spawnReplaces.copy(replacees);
+
+        // Pushes the finished struct to the array.
+        enemySpawnList.push(spawnee);
+    }
+
+    RTZSpawnEnemyEntry addEnemyEntry(string name, int chance) {
+
+        // Creates a new struct;
+        RTZSpawnEnemyEntry spawnee = RTZSpawnEnemyEntry(new('RTZSpawnEnemyEntry'));
+        spawnee.name = name;
+        spawnee.chance = chance;
+        return spawnee;
+    }
+
+    // Populates the replacement and association arrays.
+    void init() {
+
+        cvarsAvailable = true;
+
+        // --------------------
+        // Enemy spawn lists.
+        // --------------------
+
+        // Zombie Dog
+        Array<RTZSpawnEnemyEntry> spawns_zombiedog;
+        spawns_zombiedog.push(addEnemyentry('Babuin', zombiedog_spawn_bias));
+        addEnemy('ZombieDog', spawns_zombiedog, zombiedog_persistent_spawning);
+
+        // Cloaked Zombie Dog
+        Array<RTZSpawnEnemyEntry> spawns_cloaked_zombiedog;
+        spawns_cloaked_zombiedog.push(addEnemyentry('SpecBabuin', cloaked_zombiedog_spawn_bias));
+        spawns_cloaked_zombiedog.push(addEnemyentry('NinjaPirate', cloaked_zombiedog_spawn_bias));
+        addEnemy('SpecZombieDog', spawns_cloaked_zombiedog, cloaked_zombiedog_persistent_spawning);
 
 
-    // Dead Zombie Dog
-		Array<RTZSpawnEnemyEntry> spawns_dead_zombiedog;  
-		spawns_dead_zombiedog.push(addEnemyentry('DeadBabuin', zombiedog_spawn_bias));
-		addEnemy('DeadZombieDog', spawns_dead_zombiedog, zombiedog_persistent_spawning);
+        // Dead Zombie Dog
+        Array<RTZSpawnEnemyEntry> spawns_dead_zombiedog;
+        spawns_dead_zombiedog.push(addEnemyentry('DeadBabuin', zombiedog_spawn_bias));
+        addEnemy('DeadZombieDog', spawns_dead_zombiedog, zombiedog_persistent_spawning);
 
-    // Dead Cloaked Zombie Dog 
-		Array<RTZSpawnEnemyEntry> spawns_dead_cloaked_zombiedog;  
-		spawns_dead_cloaked_zombiedog.push(addEnemyentry('DeadSpecBabuin', cloaked_zombiedog_spawn_bias));
-	    spawns_dead_cloaked_zombiedog.push(addEnemyentry('DeadNinjaPirate', cloaked_zombiedog_spawn_bias));
-		addEnemy('DeadSpecZombieDog', spawns_dead_cloaked_zombiedog, cloaked_zombiedog_persistent_spawning);
+        // Dead Cloaked Zombie Dog
+        Array<RTZSpawnEnemyEntry> spawns_dead_cloaked_zombiedog;
+        spawns_dead_cloaked_zombiedog.push(addEnemyentry('DeadSpecBabuin', cloaked_zombiedog_spawn_bias));
+        spawns_dead_cloaked_zombiedog.push(addEnemyentry('DeadNinjaPirate', cloaked_zombiedog_spawn_bias));
+        addEnemy('DeadSpecZombieDog', spawns_dead_cloaked_zombiedog, cloaked_zombiedog_persistent_spawning);
 
 
-    // 10mm Rifleman
-		Array<RTZSpawnEnemyEntry> spawns_TenMilRifleman;  
-		spawns_TenMilRifleman.push(addEnemyentry('ZombieSemiStormtrooper', tenmilrifl_zombieman_spawn_bias));
-		spawns_TenMilRifleman.push(addEnemyentry('ZombieAutoStormtrooper', tenmilrifl_zombieman_spawn_bias));
-		spawns_TenMilRifleman.push(addEnemyentry('ZombieSMGStormtrooper', tenmilrifl_zombieman_spawn_bias));
-		addEnemy('TenMilRifleman', spawns_TenMilRifleman, tenmilrifl_persistent_spawning);
+        // 10mm Rifleman
+        Array<RTZSpawnEnemyEntry> spawns_TenMilRifleman;
+        spawns_TenMilRifleman.push(addEnemyentry('ZombieSemiStormtrooper', tenmilrifl_zombieman_spawn_bias));
+        spawns_TenMilRifleman.push(addEnemyentry('ZombieAutoStormtrooper', tenmilrifl_zombieman_spawn_bias));
+        spawns_TenMilRifleman.push(addEnemyentry('ZombieSMGStormtrooper', tenmilrifl_zombieman_spawn_bias));
+        addEnemy('TenMilRifleman', spawns_TenMilRifleman, tenmilrifl_persistent_spawning);
 
-    // 10mm Pistol Zombie
-		Array<RTZSpawnEnemyEntry> spawns_TenMilHomeboy;  
-		spawns_TenMilHomeboy.push(addEnemyentry('UndeadHomeboy', tenmilpis_zombieman_spawn_bias));
-		spawns_TenMilHomeboy.push(addEnemyentry('ZombieSemiStormtrooper', tenmilpis_zombieman_spawn_bias));
-		spawns_TenMilHomeboy.push(addEnemyentry('UndeadJackbootman', tenmilpis_zombieman_spawn_bias));
-		addEnemy('TenMilHomeboy', spawns_TenMilHomeboy, tenmilpis_persistent_spawning);
+        // 10mm Pistol Zombie
+        Array<RTZSpawnEnemyEntry> spawns_TenMilHomeboy;
+        spawns_TenMilHomeboy.push(addEnemyentry('UndeadHomeboy', tenmilpis_zombieman_spawn_bias));
+        spawns_TenMilHomeboy.push(addEnemyentry('ZombieSemiStormtrooper', tenmilpis_zombieman_spawn_bias));
+        spawns_TenMilHomeboy.push(addEnemyentry('UndeadJackbootman', tenmilpis_zombieman_spawn_bias));
+        addEnemy('TenMilHomeboy', spawns_TenMilHomeboy, tenmilpis_persistent_spawning);
 
-    // Sig-cow Bayonet Rifleman
-		Array<RTZSpawnEnemyEntry> spawns_Bayonetta;  
-		spawns_Bayonetta.push(addEnemyentry('ZombieSemiStormtrooper', bayonetta_zombieman_spawn_bias));
-		spawns_Bayonetta.push(addEnemyentry('ZombieAutoStormtrooper', bayonetta_zombieman_spawn_bias));
-		spawns_Bayonetta.push(addEnemyentry('ZombieSMGStormtrooper', bayonetta_zombieman_spawn_bias));
-		addEnemy('BayonetRifleman', spawns_Bayonetta, bayonetta_persistent_spawning);
+        // Sig-cow Bayonet Rifleman
+        Array<RTZSpawnEnemyEntry> spawns_Bayonetta;
+        spawns_Bayonetta.push(addEnemyentry('ZombieSemiStormtrooper', bayonetta_zombieman_spawn_bias));
+        spawns_Bayonetta.push(addEnemyentry('ZombieAutoStormtrooper', bayonetta_zombieman_spawn_bias));
+        spawns_Bayonetta.push(addEnemyentry('ZombieSMGStormtrooper', bayonetta_zombieman_spawn_bias));
+        addEnemy('BayonetRifleman', spawns_Bayonetta, bayonetta_persistent_spawning);
 
-    // Melee Zombiemen (God damn these dudes are everywhere - [Ted])
-		Array<RTZSpawnEnemyEntry> spawns_meleezombie;  
-		spawns_meleezombie.push(addEnemyentry('UndeadHomeboy', meleezomb_homeboy_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('ZombieSemiStormtrooper', meleezomb_zombieman_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('ZombieAutoStormtrooper', meleezomb_zombieman_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('ZombieSMGStormtrooper', meleezomb_zombieman_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('Jackboot', meleezomb_jackboot_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('JackAndJillboot', meleezomb_jackboot_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('UndeadJackbootman', meleezomb_jackboot_spawn_bias));
-		spawns_meleezombie.push(addEnemyentry('VulcanetteZombie', meleezomb_chaingunner_spawn_bias));
-		addEnemy('MeleeZombie', spawns_meleezombie, meleezomb_persistent_spawning);
+        // Melee Zombiemen (God damn these dudes are everywhere - [Ted])
+        Array<RTZSpawnEnemyEntry> spawns_meleezombie;
+        spawns_meleezombie.push(addEnemyentry('UndeadHomeboy', meleezomb_homeboy_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('ZombieSemiStormtrooper', meleezomb_zombieman_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('ZombieAutoStormtrooper', meleezomb_zombieman_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('ZombieSMGStormtrooper', meleezomb_zombieman_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('Jackboot', meleezomb_jackboot_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('JackAndJillboot', meleezomb_jackboot_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('UndeadJackbootman', meleezomb_jackboot_spawn_bias));
+        spawns_meleezombie.push(addEnemyentry('VulcanetteZombie', meleezomb_chaingunner_spawn_bias));
+        addEnemy('MeleeZombie', spawns_meleezombie, meleezomb_persistent_spawning);
 
-    // Brawler Jackboot
-		Array<RTZSpawnEnemyEntry> spawns_brawler;  
-		spawns_brawler.push(addEnemyentry('Jackboot', brawler_jackboot_spawn_bias));
-		spawns_brawler.push(addEnemyentry('JackAndJillboot', brawler_jackboot_spawn_bias));
-		spawns_brawler.push(addEnemyentry('UneadJackbootman', brawler_jackboot_spawn_bias));
-		addEnemy('BrawlerJackboot', spawns_brawler, brawler_persistent_spawning);
+        // Brawler Jackboot
+        Array<RTZSpawnEnemyEntry> spawns_brawler;
+        spawns_brawler.push(addEnemyentry('Jackboot', brawler_jackboot_spawn_bias));
+        spawns_brawler.push(addEnemyentry('JackAndJillboot', brawler_jackboot_spawn_bias));
+        spawns_brawler.push(addEnemyentry('UneadJackbootman', brawler_jackboot_spawn_bias));
+        addEnemy('BrawlerJackboot', spawns_brawler, brawler_persistent_spawning);
 
-    // Combat Shotgunner
-		Array<RTZSpawnEnemyEntry> spawns_combatjackboot;  
-		spawns_combatjackboot.push(addEnemyentry('Jackboot', combshot_jackboot_spawn_bias));
-	    spawns_combatjackboot.push(addEnemyentry('JackAndJillboot', combshot_jackboot_spawn_bias));
-		spawns_combatjackboot.push(addEnemyentry('UndeadJackbootman', combshot_jackboot_spawn_bias));
-		addEnemy('CombatJackboot', spawns_combatjackboot, combshot_persistent_spawning);
+        // Combat Shotgunner
+        Array<RTZSpawnEnemyEntry> spawns_combatjackboot;
+        spawns_combatjackboot.push(addEnemyentry('Jackboot', combshot_jackboot_spawn_bias));
+        spawns_combatjackboot.push(addEnemyentry('JackAndJillboot', combshot_jackboot_spawn_bias));
+        spawns_combatjackboot.push(addEnemyentry('UndeadJackbootman', combshot_jackboot_spawn_bias));
+        addEnemy('CombatJackboot', spawns_combatjackboot, combshot_persistent_spawning);
 
-    // Doomed Jackboot
-		Array<RTZSpawnEnemyEntry> spawns_doomjackboot;  
-		spawns_doomjackboot.push(addEnemyentry('Jackboot', doomjack_jackboot_spawn_bias));
-		spawns_doomjackboot.push(addEnemyentry('JackAndJillboot', doomjack_jackboot_spawn_bias));
-		spawns_doomjackboot.push(addEnemyentry('UndeadJackbootman', doomjack_jackboot_spawn_bias));
-		addEnemy('DoomedJackboot', spawns_doomjackboot, doomjack_persistent_spawning);
+        // Doomed Jackboot
+        Array<RTZSpawnEnemyEntry> spawns_doomjackboot;
+        spawns_doomjackboot.push(addEnemyentry('Jackboot', doomjack_jackboot_spawn_bias));
+        spawns_doomjackboot.push(addEnemyentry('JackAndJillboot', doomjack_jackboot_spawn_bias));
+        spawns_doomjackboot.push(addEnemyentry('UndeadJackbootman', doomjack_jackboot_spawn_bias));
+        addEnemy('DoomedJackboot', spawns_doomjackboot, doomjack_persistent_spawning);
 
-    // Riot Police Zombie
-		Array<RTZSpawnEnemyEntry> spawns_riotcop;  
-		spawns_riotcop.push(addEnemyentry('Jackboot', riot_jackboot_spawn_bias));
-	    spawns_riotcop.push(addEnemyentry('JackAndJillboot', riot_jackboot_spawn_bias));
-		spawns_riotcop.push(addEnemyentry('UndeadJackbootman', riot_jackboot_spawn_bias));
-		addEnemy('RiotCopZombie', spawns_riotcop, riot_persistent_spawning);
+        // Riot Police Zombie
+        Array<RTZSpawnEnemyEntry> spawns_riotcop;
+        spawns_riotcop.push(addEnemyentry('Jackboot', riot_jackboot_spawn_bias));
+        spawns_riotcop.push(addEnemyentry('JackAndJillboot', riot_jackboot_spawn_bias));
+        spawns_riotcop.push(addEnemyentry('UndeadJackbootman', riot_jackboot_spawn_bias));
+        addEnemy('RiotCopZombie', spawns_riotcop, riot_persistent_spawning);
 
-    // Minerva Chaingunner
-		Array<RTZSpawnEnemyEntry> spawns_minervazomb;  
-		spawns_minervazomb.push(addEnemyentry('VulcanetteZombie', minervazomb_chaingunner_spawn_bias));
-		spawns_minervazomb.push(addEnemyentry('EnemyHERP', minervazomb_herp_spawn_bias));
-		addEnemy('MinervaZombie', spawns_minervazomb, minervazomb_persistent_spawning);
-	}
-	
-	// Random stuff, stores it and forces negative values just to be 0.
-	bool giveRandom(int chance)
-	{
-		if (chance > -1)
-		{
-			let result = random(0, chance);
+        // Minerva Chaingunner
+        Array<RTZSpawnEnemyEntry> spawns_minervazomb;
+        spawns_minervazomb.push(addEnemyentry('VulcanetteZombie', minervazomb_chaingunner_spawn_bias));
+        spawns_minervazomb.push(addEnemyentry('EnemyHERP', minervazomb_herp_spawn_bias));
+        addEnemy('MinervaZombie', spawns_minervazomb, minervazomb_persistent_spawning);
+    }
 
-			if (hd_debug) console.printf("Rolled a "..(result + 1).." out of "..(chance + 1));
+    // Random stuff, stores it and forces negative values just to be 0.
+    bool giveRandom(int chance) {
+        if (chance > -1) {
+            let result = random(0, chance);
 
-			return result == 0;
-		}
-		
-		return false;
-	}
+            if (hd_debug) console.printf("Rolled a "..(result + 1).." out of "..(chance + 1));
+
+            return result == 0;
+        }
+
+        return false;
+    }
 
     // Tries to replace the item during spawning.
-    bool tryReplaceEnemy(ReplaceEvent e, string spawnName, int chance)
-	{
-        if (giveRandom(chance))
-		{
+    bool tryReplaceEnemy(ReplaceEvent e, string spawnName, int chance) {
+        if (giveRandom(chance)) {
             if (hd_debug) console.printf(e.replacee.getClassName().." -> "..spawnName);
 
             e.replacement = spawnName;
 
             return true;
-		}
-
-		return false;
-	}
-
-	// Tries to create the Enemy via random spawning.
-	bool tryCreateEnemy(Actor thing, string spawnName, int chance)
-	{
-		if (giveRandom(chance))
-		{
-			if (hd_debug) console.printf(thing.getClassName().." + "..spawnName);
-
-			Actor.Spawn(spawnName, thing.pos);
-
-			return true;
-		}
+        }
 
         return false;
     }
 
-	override void worldLoaded(WorldEvent e)
-	{
-		// Populates the main arrays if they haven't been already. 
-		if (!cvarsAvailable) init();
-	}
+    // Tries to create the Enemy via random spawning.
+    bool tryCreateEnemy(Actor thing, string spawnName, int chance) {
+        if (giveRandom(chance)) {
+            if (hd_debug) console.printf(thing.getClassName().." + "..spawnName);
 
-    override void checkReplacement(ReplaceEvent e)
-	{
-		// Populates the main arrays if they haven't been already. 
-		if (!cvarsAvailable) init();
+            Actor.Spawn(spawnName, thing.pos);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    override void worldLoaded(WorldEvent e) {
+
+        // Populates the main arrays if they haven't been already.
+        if (!cvarsAvailable) init();
+    }
+
+    override void checkReplacement(ReplaceEvent e) {
+
+        // Populates the main arrays if they haven't been already.
+        if (!cvarsAvailable) init();
 
         // If there's nothing to replace or if the replacement is final, quit.
         if (!e.replacee || e.isFinal) return;
@@ -269,70 +260,64 @@ class RadtechZombiesHandler : EventHandler
 
         handleEnemyReplacements(e, candidateName);
     }
-	
-	override void worldThingSpawned(WorldEvent e)
-	 {
-		// Populates the main arrays if they haven't been already. 
-		if (!cvarsAvailable) init();
 
-		// If thing spawned doesn't exist, quit.
-		if (!e.thing) return;
+    override void worldThingSpawned(WorldEvent e) {
 
-		// If thing spawned is blacklisted, quit.
-		foreach (bl : blacklist) if (e.thing is bl) return;
+        // Populates the main arrays if they haven't been already.
+        if (!cvarsAvailable) init();
 
-		string candidateName = e.thing.getClassName();
+        // If thing spawned doesn't exist, quit.
+        if (!e.thing) return;
+
+        // If thing spawned is blacklisted, quit.
+        foreach (bl : blacklist) if (e.thing is bl) return;
+
+        string candidateName = e.thing.getClassName();
 
         // If current map is Range, quit.
         if (level.MapName == 'RANGE') return;
 
-		handleEnemySpawns(e.thing, candidateName);
-	}
+        handleEnemySpawns(e.thing, candidateName);
+    }
 
-	private void handleEnemyReplacements(ReplaceEvent e, string candidateName)
-	{
-		// Checks if the level has been loaded more than 1 tic.
-		bool prespawn = !(level.maptime > 1);
+    private void handleEnemyReplacements(ReplaceEvent e, string candidateName) {
 
-		// Iterates through the list of Enemy candidates for thing.
-		foreach (enemySpawn : enemySpawnList)
-		{
-			if ((prespawn || enemySpawn.isPersistent) && enemySpawn.replaceEnemy)
-			{
-				foreach (spawnReplace : enemySpawn.spawnReplaces)
-				{
-					if (spawnReplace.name ~== candidateName)
-					{
-						if (hd_debug) console.printf("Attempting to replace "..candidateName.." with "..enemySpawn.spawnName.."...");
-
-						if (tryReplaceEnemy(e, enemySpawn.spawnName, spawnReplace.chance)) return;
-					}
-				}
-			}
-		}
-	}
-
-    private void handleEnemySpawns(Actor thing, string candidateName)
-	{
         // Checks if the level has been loaded more than 1 tic.
         bool prespawn = !(level.maptime > 1);
 
         // Iterates through the list of Enemy candidates for e.thing.
-        foreach (enemySpawn : enemySpawnList)
-		{    
-            // if an Enemy is owned or is an ammo (doesn't retain owner ptr), 
-            // do not replace it. 
+        foreach (enemySpawn : enemySpawnList) {
+
+            if ((prespawn || enemySpawn.isPersistent) && enemySpawn.replaceEnemy) {
+                foreach (spawnReplace : enemySpawn.spawnReplaces) {
+                    if (spawnReplace.name ~== candidateName) {
+                        if (hd_debug) console.printf("Attempting to replace "..candidateName.." with "..enemySpawn.spawnName.."...");
+
+                        if (tryReplaceEnemy(e, enemySpawn.spawnName, spawnReplace.chance)) return;
+                    }
+                }
+            }
+        }
+    }
+
+    private void handleEnemySpawns(Actor thing, string candidateName) {
+
+        // Checks if the level has been loaded more than 1 tic.
+        bool prespawn = !(level.maptime > 1);
+
+        // Iterates through the list of Enemy candidates for e.thing.
+        foreach (enemySpawn : enemySpawnList) {
+
+            // if an Enemy is owned or is an ammo (doesn't retain owner ptr),
+            // do not replace it.
             let item = Inventory(thing);
             if (
                 (prespawn || enemySpawn.isPersistent)
              && (!(item && item.owner) && prespawn)
              && !enemySpawn.replaceEnemy
-            )
-			{
-                foreach (spawnReplace : enemySpawn.spawnReplaces)
-				{
-                    if (spawnReplace.name ~== candidateName)
-					{
+            ) {
+                foreach (spawnReplace : enemySpawn.spawnReplaces) {
+                    if (spawnReplace.name ~== candidateName) {
                         if (hd_debug) console.printf("Attempting to spawn "..enemySpawn.spawnName.." with "..candidateName.."...");
 
                         if (tryCreateEnemy(thing, enemySpawn.spawnName, spawnReplace.chance)) return;

--- a/zscript/RiotCopZombie/mob_RiotCopZombie.zs
+++ b/zscript/RiotCopZombie/mob_RiotCopZombie.zs
@@ -60,11 +60,11 @@ class RiotCopZombie:HDHumanoid{
 	override void deathdrop(){
 		A_NoBlocking();
 		if(bhasdropped){
-			if(!bfriendly && llh_shotgun_spawn_bias > -1)
+			if(!bfriendly && llh_hunter_spawn_bias > -1)
 			{
 				DropNewItem("LLShellPickup",200);
 			}
-			if(!bfriendly && llh_shotgun_spawn_bias == -1)
+			if(!bfriendly && llh_hunter_spawn_bias == -1)
 			{
 				DropNewItem("ShellPickup",200);
 			}
@@ -73,11 +73,11 @@ class RiotCopZombie:HDHumanoid{
 			bhasdropped=true;
 			hdweapon wp=null;
 
-			if(wep==0 && llh_shotgun_spawn_bias == -1)
+			if(wep==0 && llh_hunter_spawn_bias == -1)
 			{
 				DropNewItem("ShellPickup");
 			}
-			if(wep==0 && llh_shotgun_spawn_bias > -1)
+			if(wep==0 && llh_hunter_spawn_bias > -1)
 			{
 				wp=DropNewWeapon("LLHunter");
 				if(wp){


### PR DESCRIPTION
Similar to the work I've been putting into other community packs, these changes update the spawn handler to leverage the `CheckReplacement` logic if the spawn entries are marked to actually replace, rather than spawn alongside their checked actor(s).  This allows for dummy spawners and other classes that get immediately replaced via other means.

The file also had its formatting tweaked to be more consistent with the others, as it helps aid in comparing/merging the differences between handlers.