### PR TITLE
Refine checks for non-replaced enemy spawns

### DIFF
--- a/zscript/RadTechZombie_Spawners.zs
+++ b/zscript/RadTechZombie_Spawners.zs
@@ -308,12 +308,14 @@ class RadtechZombiesHandler : EventHandler {
         // Iterates through the list of Enemy candidates for e.thing.
         foreach (enemySpawn : enemySpawnList) {
 
-            // if an Enemy is owned or is an ammo (doesn't retain owner ptr),
-            // do not replace it.
+            // if currently in pre-spawn or configured to be persistent,
+            // and original thing being spawned is not an owned item,
+            // and not configured to replace original spawn,
+            // attempt to spawn new thing.
             let item = Inventory(thing);
             if (
                 (prespawn || enemySpawn.isPersistent)
-             && (!(item && item.owner) && prespawn)
+             && !(item && item.owner)
              && !enemySpawn.replaceEnemy
             ) {
                 foreach (spawnReplace : enemySpawn.spawnReplaces) {


### PR DESCRIPTION
Seems I missed a bit of logic when unifying the various spawn handlers a while back, missed the situations where you don't want your mobs to replace the original thing being spawned after pre-spawn.  Since the prespawn/persistence check is already being made and because we're mainly swapping monsters around, I've removed that part of the check.